### PR TITLE
Mod: Add preliminary support for Black Mesa: Blue Shift

### DIFF
--- a/GameHandling/GameSupport.Cases.cs
+++ b/GameHandling/GameSupport.Cases.cs
@@ -1,10 +1,11 @@
-﻿using LiveSplit.SourceSplit.Utilities;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.IO;
+using LiveSplit.SourceSplit.Utilities;
 using LiveSplit.SourceSplit.GameSpecific;
 using LiveSplit.SourceSplit.GameSpecific.HL2Mods;
 using LiveSplit.SourceSplit.GameSpecific.PortalMods;
-using System.IO;
+using LiveSplit.SourceSplit.GameSpecific.BMSMods;
 
 namespace LiveSplit.SourceSplit.GameHandling
 {
@@ -41,6 +42,8 @@ namespace LiveSplit.SourceSplit.GameHandling
                     return new TheFlashVersion();
                 case "bms":
                     return new BMSRetail();
+                case "bshift":
+                    return new BlackMesaBlueShift();
                 case "lostcoast":
                     return new LostCoast();
                 case "estrangedact1":

--- a/GameSpecific/BMSMods/BlackMesaBlueShift.cs
+++ b/GameSpecific/BMSMods/BlackMesaBlueShift.cs
@@ -1,0 +1,21 @@
+﻿namespace LiveSplit.SourceSplit.GameSpecific.BMSMods;
+
+class BlackMesaBlueShift : BMSBase
+{
+    public BlackMesaBlueShift()
+    {
+        // Insecurity: first map
+        // Could be changed to Duty Calls instead if we decide cutscenes
+        // are too boring but probably not.
+        this.AddFirstMap("bs_c1m0a");
+        // Focal Point: last map
+        // TODO: Change this as more chapters are released.
+        this.AddLastMap("bs_c4m2c");
+
+        this.StartOnFirstLoadMaps.AddRange(this.FirstMaps);
+
+        // End when player enters the portal in bs_c4m2c.
+        // TODO: Remove this as more chapters are released.
+        this.WhenOutputIsQueued(ActionType.AutoEnd, "interdim_shaft_rel");
+    }
+}


### PR DESCRIPTION
Adds basic support for Black Mesa: Blue Shift to enforce SourceSplit rules for Black Mesa without needing to modify settings manually. Sets up auto start in Chapter 2, Insecurity (ignoring tram ride in Chapter 1) and sets up auto end when player enters portal back to Earth at the end of Focal Point. Modifications are expected down the line when the mod is completed.